### PR TITLE
fix[scripts]: address review of dev-scripts toolbox

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,10 @@ repos:
       - id: insert-license
         types: [python]
         args: [--comment-style, "|#|", --license-filepath, ./HEADER.txt, --fuzzy-match-generates-todo]
+      - id: insert-license
+        name: insert-license (dev-script entry points)
+        files: ^scripts/(run|test)$  # extensionless 'uv run' scripts are not detected as python
+        args: [--comment-style, "|#|", --license-filepath, ./HEADER.txt, --fuzzy-match-generates-todo]
 
   # The following hooks use development tools which are already managed by 'uv'.
   # To avoid inconsistencies between the development and the pre-commit
@@ -74,10 +78,24 @@ repos:
         require_serial: true
 
       - <<: *uv-managed-hook
+        id: ruff-check
+        name: ruff checker (dev-script entry points)
+        entry: uv run --group dev --frozen --isolated ruff check --force-exclude --fix
+        files: ^scripts/(run|test)$  # extensionless 'uv run' scripts are not detected as python
+        require_serial: true
+
+      - <<: *uv-managed-hook
         id: ruff-format
         name: ruff formatter
         entry: uv run --group dev --frozen --isolated ruff format --force-exclude
         types_or: [python, pyi, jupyter]
+        require_serial: true
+
+      - <<: *uv-managed-hook
+        id: ruff-format
+        name: ruff formatter (dev-script entry points)
+        entry: uv run --group dev --frozen --isolated ruff format --force-exclude
+        files: ^scripts/(run|test)$  # extensionless 'uv run' scripts are not detected as python
         require_serial: true
 
       - <<: *uv-managed-hook

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,8 +52,12 @@ scripts/
 
 **Bash scripts**
 
-- Source `_lib.sh` for shared helpers:
-  `source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"`
+- Set strict mode and source `_lib.sh` for shared helpers (`_lib.sh` does not
+  set shell options itself):
+  ```bash
+  set -euo pipefail
+  source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+  ```
 - Add `# [help] ...` comment lines to customize the help text shown by
   `./scripts/run`.
 

--- a/scripts/run
+++ b/scripts/run
@@ -56,11 +56,11 @@ if __name__ == "__main__":
         # Then add the 'python' folder to sys.path to mimic the `sys.path` of the
         # command modules run directly as scripts.
         sys.path.insert(0, python_scripts_dir)
-        from helpers import common  # noqa: F401 - just to check that it can be imported
+        from helpers import common
 
     except ImportError as e:
         print(
-            f"ERROR: '{e.name}' package cannot be imported!!\n"
+            f"ERROR: '{e.name}' package cannot be imported.\n"
             "Make sure 'uv' is installed in your system and run directly this script "
             "as an executable file, to let 'uv' create a temporary venv with all the "
             "required dependencies.\n",
@@ -82,10 +82,7 @@ if __name__ == "__main__":
         if not name.startswith("_") and not ispkg:
             module = importlib.import_module(f"python.{name}")
             if hasattr(module, "cli") and isinstance(module.cli, typer.Typer):
-                if len(module.cli.registered_commands) > 1:
-                    app.add_typer(module.cli, name=module.cli.info.name or name)
-                else:
-                    app.add_typer(module.cli)
+                app.add_typer(module.cli, name=module.cli.info.name or name)
 
     # -- Shell sub-commands (auto-discovered wrappers) --
     def _extract_shell_help(script_path: pathlib.Path) -> str | None:

--- a/scripts/sh/_lib.sh
+++ b/scripts/sh/_lib.sh
@@ -9,10 +9,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # Shared functions for bash dev-scripts.  Source, don't execute.
+# Sourcing must not change the caller's shell options, so each executable
+# script is responsible for its own `set -euo pipefail`.
 # Usage (in sibling scripts):
+#   set -euo pipefail
 #   source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
-
-set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/test
+++ b/scripts/test
@@ -13,8 +13,8 @@
 Unified scripts tests entry point.
 
 Provides two sub-commands:
-- ``python``: run python scripts tests at ``scripts/tests/python`` (pytest cwd is ``scripts/tests/python``).
-- ``sh``: run bash scripts tests with bats from ``scripts/tests/sh``.
+- ``python``: run pytest in ``scripts/tests/python``.
+- ``sh``: run bats in ``scripts/tests/sh``.
 
 Usage:
     ./scripts/test --help
@@ -51,11 +51,11 @@ if __name__ == "__main__":
         # Then add the 'python' folder to sys.path to mimic the `sys.path` of the
         # command modules run directly as scripts.
         sys.path.insert(0, python_scripts_dir)
-        from helpers import common  # noqa: F401 - just to check that it can be imported
+        from helpers import common
 
     except ImportError as e:
         print(
-            f"ERROR: '{e.name}' package cannot be imported!!\n"
+            f"ERROR: '{e.name}' package cannot be imported.\n"
             "Make sure 'uv' is installed in your system and run directly this script "
             "as an executable file, to let 'uv' create a temporary venv with all the "
             "required dependencies.\n",
@@ -76,12 +76,6 @@ if __name__ == "__main__":
             typer.Argument(help="Pytest arguments to forward. Pass them after '--'."),
         ] = None,
     ):
-        if pytest_args and "--" not in sys.argv:
-            raise typer.BadParameter(
-                "Pytest arguments must be passed after '--', for example: "
-                "./scripts/test python -- -k common"
-            )
-
         cmd = ["pytest", *(pytest_args or [])]
         base_dir = common.SCRIPTS_DIR / "tests" / "python"
         rich.print(f"Running: {base_dir} $ {' '.join(cmd)}\n")
@@ -98,7 +92,7 @@ if __name__ == "__main__":
                 "ERROR: 'bats' executable cannot be found. Install bats-core to run shell tests.",
                 file=sys.stderr,
             )
-            raise SystemExit(127)
+            raise SystemExit(127) from None
         raise SystemExit(result.returncode)
 
     app()


### PR DESCRIPTION
Follow-up to the dev-scripts restructuring in GridTools/gt4py#2653, targeting your `update-python-script` branch. These are fixes from a code review of that PR.

### Fixes

- **pre-commit coverage regression.** `scripts/run` and `scripts/test` are extensionless with a `uv run … python3` shebang, so `identify` tags them `['executable','file','text']` — no `python` tag. The `ruff-check`, `ruff-format` (`types_or: [python,…]`) and `insert-license` (`types: [python]`) hooks therefore skip them entirely, whereas the deleted `scripts-cli.py` (a `.py` file) was covered. Added dedicated hook entries scoped to `^scripts/(run|test)$` so both files get lint, format, and license enforcement again. (This also surfaced an unused `# noqa` and a `B904`, fixed here.)

- **`sh/_lib.sh` leaked shell options.** The file is documented "source, don't execute", but the top-level `set -euo pipefail` mutated the *caller's* shell — sourcing it turns on `errexit` for the sibling script / interactive session. Dropped it; each executable script sets its own strict mode (README updated to show the pattern).

- **Sub-command registration footgun (`run`).** `if len(registered_commands) > 1: add_typer(name=…) else: add_typer()` silently flattens a single-command module without an explicit `name=` to the top level (and changes its invocation path once a second command is added). All current modules have ≥2 commands so behavior is unchanged today; simplified to always namespace.

- **Dead/misleading `--` guard (`test python`).** The `BadParameter` hint never fires for option-style args (`./scripts/test python -k common` → Click `No such option: -k` first) and it wrongly rejected valid bare positionals (`./scripts/test python test_common.py`). Removed it; option forwarding still works via `--`, and bare positionals now forward too.

- **minor:** avoid `!!` in error messages (CODING_GUIDELINES), wrap an over-long docstring line.

### Verification

`./scripts/run --help`, `./scripts/test python` (with `--`, bare positionals, and the `sh` path), and `uv run pre-commit run --files …` all pass; the new hooks are confirmed to run on `scripts/run` and `scripts/test`.